### PR TITLE
Fix for finding latest version number

### DIFF
--- a/updateOmbi.sh
+++ b/updateOmbi.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 DOWNLOAD=linux-x64.tar.gz
+DOWNLOAD_SEARCH=.tar.gz
 SERVICE_NAME=ombi
 OMBI_URL=https://github.com/Ombi-app/Ombi/releases
-VERSION=$(curl -s $OMBI_URL | grep "$DOWNLOAD" | grep -Po ".*\/download\/v([0-9\.]+).*" | awk -F'/' '{print $6}' | tr -d 'v' | sort -V | tail -1)
+OMBI_URL_SEARCH=https://github.com/Ombi-app/Ombi/tags
+VERSION=$(curl -s $OMBI_URL_SEARCH | grep "$DOWNLOAD_SEARCH" | grep -Po ".*\/tags\/v([0-9\.]+).*" | awk -F'/' '{print $7}' | cut -c 1-7 | tr -d 'v' | sort -V | tail -1)
 SERVICE_LOC=$(systemctl status $SERVICE_NAME | grep -Po "(?<=loaded \()[^;]+")
 WORKING_DIR=$(grep -Po "(?<=WorkingDirectory=).*" $SERVICE_LOC)
 INSTALLED_1=$(strings $WORKING_DIR/Ombi | grep -Po 'Ombi/\d+\.\d+\.\d+' | grep -Po '\d+\.\d+\.\d+' | sort -n | tail -n 1)


### PR DESCRIPTION
I'm sure there is a better way of doing this. GitHub does not show the 'Assets' portion automatically anymore on the releases page. This was the easiest way I could think of to grab the latest version number while leaving the rest of the code as is because it still works (the updating based off the old URL).